### PR TITLE
Add study plan generation and syllabus review UI

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,18 +1,31 @@
 const mongoose = require("mongoose");
 const MONGODB_URI = process.env.MONGODB_URI;
 
-//connect to mongodb
+// separate connection for studyplans db
+let studyplansConnection = null;
+
+// connect to mongodb (default db for users, separate for studyplans)
 const connectDB = async () => {
     try {
         const uri = MONGODB_URI;
 
         await mongoose.connect(uri);
+        console.log("MongoDB connected successfully (default)");
 
-        console.log("MongoDB connected successfully");
+        // studyplans lives in a different database
+        studyplansConnection = mongoose.createConnection(uri, { dbName: "studyplans" });
+        studyplansConnection.on("connected", () => {
+            console.log("MongoDB connected to 'studyplans' database");
+        });
+        studyplansConnection.on("error", (err) => {
+            console.error("Studyplans DB connection error:", err);
+        });
     } catch (err) {
         console.error("MongoDB connection error:", err.message);
         process.exit(1);
     }
 };
 
-module.exports = { connectDB, mongoose };
+const getStudyplansConnection = () => studyplansConnection;
+
+module.exports = { connectDB, mongoose, getStudyplansConnection };

--- a/backend/controllers/studyPlanController.js
+++ b/backend/controllers/studyPlanController.js
@@ -1,0 +1,160 @@
+const { getStudyPlanModel } = require("../models/StudyPlan");
+
+// get most recent study plan for user
+// GET /api/studyplans/latest
+exports.getLatestStudyPlan = async (req, res) => {
+    try {
+        const StudyPlan = getStudyPlanModel();
+        if (!StudyPlan) {
+            return res.status(503).json({ error: "Database not ready" });
+        }
+
+        const userId = req.user?._id?.toString();
+
+        if (!userId) {
+            return res.status(401).json({ error: "User not authenticated" });
+        }
+
+        const studyPlan = await StudyPlan.findOne({ userId })
+            .sort({ savedAt: -1 })
+            .lean();
+
+        if (!studyPlan) {
+            return res.status(404).json({ error: "No study plan found for this user" });
+        }
+
+        res.json({ studyPlan });
+    } catch (err) {
+        console.error("[StudyPlan] Error fetching latest:", err);
+        res.status(500).json({ error: "Failed to fetch study plan" });
+    }
+};
+
+// get study plan history for user
+// GET /api/studyplans/history
+exports.getStudyPlanHistory = async (req, res) => {
+    try {
+        const StudyPlan = getStudyPlanModel();
+        if (!StudyPlan) {
+            return res.status(503).json({ error: "Database not ready" });
+        }
+
+        const userId = req.user?._id?.toString();
+
+        if (!userId) {
+            return res.status(401).json({ error: "User not authenticated" });
+        }
+
+        const limit = parseInt(req.query.limit) || 10;
+
+        const studyPlans = await StudyPlan.find({ userId })
+            .sort({ savedAt: -1 })
+            .limit(limit)
+            .lean();
+
+        res.json({ studyPlans, count: studyPlans.length });
+    } catch (err) {
+        console.error("[StudyPlan] Error fetching history:", err);
+        res.status(500).json({ error: "Failed to fetch study plan history" });
+    }
+};
+
+// get specific study plan by id
+// GET /api/studyplans/:id
+exports.getStudyPlanById = async (req, res) => {
+    try {
+        const StudyPlan = getStudyPlanModel();
+        if (!StudyPlan) {
+            return res.status(503).json({ error: "Database not ready" });
+        }
+
+        const userId = req.user?._id?.toString();
+        const { id } = req.params;
+
+        if (!userId) {
+            return res.status(401).json({ error: "User not authenticated" });
+        }
+
+        const studyPlan = await StudyPlan.findById(id).lean();
+
+        if (!studyPlan) {
+            return res.status(404).json({ error: "Study plan not found" });
+        }
+
+        // check ownership
+        if (studyPlan.userId !== userId) {
+            return res.status(403).json({ error: "Access denied" });
+        }
+
+        res.json({ studyPlan });
+    } catch (err) {
+        console.error("[StudyPlan] Error fetching by ID:", err);
+        res.status(500).json({ error: "Failed to fetch study plan" });
+    }
+};
+
+// get calendar entries from latest study plan
+// GET /api/studyplans/calendar
+exports.getCalendarEntries = async (req, res) => {
+    try {
+        const StudyPlan = getStudyPlanModel();
+        if (!StudyPlan) {
+            return res.status(503).json({ error: "Database not ready" });
+        }
+
+        const userId = req.user?._id?.toString();
+        console.log("[StudyPlan] getCalendarEntries - userId:", userId);
+
+        if (!userId) {
+            return res.status(401).json({ error: "User not authenticated" });
+        }
+
+        // debug: check whats in the collection
+        const allPlans = await StudyPlan.find({}).lean();
+        console.log("[StudyPlan] all plans in db:", allPlans.length, "userIds:", allPlans.map(p => p.userId));
+
+        const studyPlan = await StudyPlan.findOne({ userId })
+            .sort({ savedAt: -1 })
+            .lean();
+
+        console.log("[StudyPlan] Found plan:", studyPlan ? "yes" : "no");
+
+        if (!studyPlan) {
+            return res.status(404).json({ error: "No study plan found" });
+        }
+
+        // group entries by assessment
+        const calendarEntries = [];
+
+        for (const course of studyPlan.courses || []) {
+            for (const entry of course.entries || []) {
+                calendarEntries.push({
+                    course: course.course,
+                    assessmentName: entry.assessmentName,
+                    assessmentType: entry.assessmentType,
+                    dueDate: entry.dueDate || null,
+                    studyPeriod: entry.studyPeriod || null,
+                    tasks: entry.tasks || [],
+                });
+            }
+        }
+
+        // sort by due date (nulls last)
+        calendarEntries.sort((a, b) => {
+            if (!a.dueDate) return 1;
+            if (!b.dueDate) return -1;
+            return new Date(a.dueDate) - new Date(b.dueDate);
+        });
+
+        res.json({
+            entries: calendarEntries,
+            count: calendarEntries.length,
+            studyPlanId: studyPlan._id,
+            savedAt: studyPlan.savedAt,
+        });
+    } catch (err) {
+        console.error("[StudyPlan] Error fetching calendar entries:", err);
+        res.status(500).json({ error: "Failed to fetch calendar entries" });
+    }
+};
+

--- a/backend/models/StudyPlan.js
+++ b/backend/models/StudyPlan.js
@@ -1,0 +1,54 @@
+const mongoose = require("mongoose");
+const { getStudyplansConnection } = require("../config/db");
+
+// study plan schema - matches n8n workflow output
+
+const taskSchema = new mongoose.Schema({
+    task: { type: String },
+    description: { type: String },
+    estimatedTime: { type: String },
+}, { _id: false });
+
+const studyPeriodSchema = new mongoose.Schema({
+    start: { type: String },
+    end: { type: String },
+}, { _id: false });
+
+const entrySchema = new mongoose.Schema({
+    assessmentName: { type: String, required: true },
+    assessmentType: { type: String, required: true },
+    dueDate: { type: String },
+    studyPeriod: { type: studyPeriodSchema },
+    tasks: [taskSchema],
+}, { _id: false });
+
+const courseSchema = new mongoose.Schema({
+    course: { type: String, required: true },
+    entries: [entrySchema],
+}, { _id: false });
+
+const studyPlanSchema = new mongoose.Schema({
+    userId: { type: String, required: true, index: true },
+    courses: [courseSchema],
+    totalCourses: { type: Number },
+    savedAt: { type: Date, default: Date.now, index: true },
+});
+
+// index for getting most recent by user
+studyPlanSchema.index({ userId: 1, savedAt: -1 });
+
+// uses the studyplans database connection
+let StudyPlan = null;
+
+const getStudyPlanModel = () => {
+    if (!StudyPlan) {
+        const conn = getStudyplansConnection();
+        if (conn) {
+            StudyPlan = conn.model("StudyPlan", studyPlanSchema, "tasks");
+        }
+    }
+    return StudyPlan;
+};
+
+module.exports = { getStudyPlanModel, studyPlanSchema };
+

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
                 "cors": "^2.8.5",
                 "dotenv": "^17.2.3",
                 "express": "^5.1.0",
+                "form-data": "^4.0.5",
                 "jsonwebtoken": "^9.0.2",
                 "mongoose": "^8.19.1",
                 "multer": "^1.4.5-lts.1"
@@ -1784,8 +1785,7 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/babel-jest": {
             "version": "30.1.2",
@@ -2287,7 +2287,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -2471,7 +2470,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -2618,7 +2616,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "dev": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "get-intrinsic": "^1.2.6",
@@ -3130,10 +3127,10 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-            "dev": true,
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -3149,7 +3146,6 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3158,7 +3154,6 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -3386,7 +3381,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dev": true,
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "form-data": "^4.0.5",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.19.1",
         "multer": "^1.4.5-lts.1"

--- a/backend/routes/studyPlanRoutes.js
+++ b/backend/routes/studyPlanRoutes.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const router = express.Router();
+const studyPlanController = require("../controllers/studyPlanController");
+const { userAuthMiddleware } = require("../middleware/authMiddleware");
+
+// all routes require auth
+router.use(userAuthMiddleware);
+
+router.get("/latest", studyPlanController.getLatestStudyPlan);
+router.get("/calendar", studyPlanController.getCalendarEntries);
+router.get("/history", studyPlanController.getStudyPlanHistory);
+router.get("/:id", studyPlanController.getStudyPlanById);
+
+module.exports = router;
+

--- a/frontend/app/(tabs)/syllabus/_layout.jsx
+++ b/frontend/app/(tabs)/syllabus/_layout.jsx
@@ -22,7 +22,8 @@ const SyllabusLayout = () => {
                 },
             }}
         >
-            <Stack.Screen name="index" options={{ title: "Syallbus" }} />
+            <Stack.Screen name="index" options={{ title: "Syllabus" }} />
+            <Stack.Screen name="questions" options={{ title: "Study Plan" }} />
         </Stack>
     );
 };

--- a/frontend/app/(tabs)/syllabus/index.jsx
+++ b/frontend/app/(tabs)/syllabus/index.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { View, Text, StyleSheet, TouchableOpacity, Dimensions, Platform, ScrollView, FlatList, Modal, TextInput } from "react-native";
+import { View, Text, StyleSheet, TouchableOpacity, Dimensions, Platform, ScrollView, Modal, TextInput } from "react-native";
 import { Feather } from "@expo/vector-icons";
 import Colors from "@/constants/Colors";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -625,7 +625,7 @@ function CoursePage({ course, courseIndex, availableHeight, onEditSection }) {
     if (!list || list.length === 0) {
       return (
         <Text style={styles.emptyText}>
-          Orbit couldn't detect any {label?.toLowerCase?.()}. Would you like to add some?
+          Orbit could not detect any {label?.toLowerCase?.()}. Would you like to add some?
         </Text>
       );
     }

--- a/frontend/app/(tabs)/syllabus/index.jsx
+++ b/frontend/app/(tabs)/syllabus/index.jsx
@@ -1,9 +1,11 @@
-import React, { useCallback, useMemo, useState } from "react";
-import { View, Text, StyleSheet, TouchableOpacity, Dimensions, Platform, ScrollView } from "react-native";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { View, Text, StyleSheet, TouchableOpacity, Dimensions, Platform, ScrollView, FlatList, Modal, TextInput } from "react-native";
 import { Feather } from "@expo/vector-icons";
 import Colors from "@/constants/Colors";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import * as DocumentPicker from "expo-document-picker";
+import { useSyllabus } from "@/context/SyllabusContext";
+import { useRouter } from "expo-router";
 
 export default function SyllabusScreen() {
   const insets = useSafeAreaInsets();
@@ -11,6 +13,11 @@ export default function SyllabusScreen() {
   const [status, setStatus] = useState("idle");
   const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
+  const [courses, setCourses] = useState([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef(null);
+  const { setCourses: setCoursesCtx, setRawResult: setRawResultCtx, setUploadId: setUploadIdCtx, setUploadedFiles: setUploadedFilesCtx } = useSyllabus();
+  const router = useRouter();
 
   const allowedMimeTypes = useMemo(() => [
     "application/pdf",
@@ -69,6 +76,7 @@ export default function SyllabusScreen() {
       const uploadResp = await fetch(`${apiBaseUrl}/api/uploads`, { method: "POST", body: form });
       if (!uploadResp.ok) throw new Error("Upload failed");
       const { uploadId } = await uploadResp.json();
+      setUploadIdCtx(uploadId);
       setStatus("processing");
 
       let attempts = 0;
@@ -80,6 +88,9 @@ export default function SyllabusScreen() {
           const data = await s.json();
           if (data.status === "completed") {
             setResult(data.result);
+            if (Array.isArray(data.files)) {
+              setUploadedFilesCtx(data.files);
+            }
             setStatus("done");
             return;
           }
@@ -96,6 +107,139 @@ export default function SyllabusScreen() {
       setStatus("error");
     }
   }, [allowedMimeTypes, apiBaseUrl, validateFile]);
+
+  // normalize webhook payload into course array
+  const normalizeSyllabusResult = useCallback((payload) => {
+    if (!payload) return [];
+    if (Array.isArray(payload)) {
+      // [{ syllabi: [...courses] }]
+      if (payload.length === 1 && Array.isArray(payload[0]?.syllabi)) {
+        const list = payload[0].syllabi;
+        return list.map((c) => ({
+          name: c.course || c.courseName || c.name || "Course",
+          exams: c.exams || [],
+          projects: c.projects || [],
+          assignments: c.assignments || [],
+          quizzes: c.quizzes || [],
+        }));
+      }
+      // array of courses
+      const looksLikeCourses = payload.every(
+        (c) =>
+          c &&
+          typeof c === "object" &&
+          (Array.isArray(c.exams) ||
+            Array.isArray(c.projects) ||
+            Array.isArray(c.assignments) ||
+            Array.isArray(c.quizzes) ||
+            c.course ||
+            c.courseName ||
+            c.name)
+      );
+      if (looksLikeCourses) {
+        return payload.map((c) => ({
+          name: c.course || c.courseName || c.name || "Course",
+          exams: c.exams || [],
+          projects: c.projects || [],
+          assignments: c.assignments || [],
+          quizzes: c.quizzes || [],
+        }));
+      }
+      return [];
+    }
+    // { syllabi: [...courses] }
+    if (Array.isArray(payload.syllabi)) {
+      const list = payload.syllabi;
+      return list.map((c) => ({
+        name: c.course || c.courseName || c.name || "Course",
+        exams: c.exams || [],
+        projects: c.projects || [],
+        assignments: c.assignments || [],
+        quizzes: c.quizzes || [],
+      }));
+    }
+    if (Array.isArray(payload.courses)) return payload.courses;
+    if (payload.data && Array.isArray(payload.data.courses)) return payload.data.courses;
+    // object keyed by course name
+    const keys = Object.keys(payload || {}).filter((k) => {
+      const v = payload[k];
+      return typeof v === "object" && v !== null && !Array.isArray(v);
+    });
+    const looksLikeCourseMap = keys.length > 0 && !("files" in payload) && !("summary" in payload) && !("uploadId" in payload);
+    if (looksLikeCourseMap) {
+      return keys.map((name) => {
+        const course = payload[name] || {};
+        return {
+          name: course.name || course.courseName || name,
+          exams: course.exams || course.Exams || [],
+          projects: course.projects || course.Projects || [],
+          assignments: course.assignments || course.Assignments || [],
+          quizzes: course.quizzes || course.Quizzes || [],
+        };
+      });
+    }
+    // single course fallback
+    if (payload.course || payload.courseName) {
+      return [{
+        name: payload.course?.name || payload.courseName || "Course",
+        exams: payload.exams || [],
+        projects: payload.projects || [],
+        assignments: payload.assignments || [],
+        quizzes: payload.quizzes || [],
+      }];
+    }
+    return [];
+  }, []);
+
+  useEffect(() => {
+    if (status === "done" && result) {
+      const normalized = normalizeSyllabusResult(result);
+      setCourses(normalized);
+      setCoursesCtx(normalized);
+      setRawResultCtx(result);
+      setActiveIndex(0);
+    }
+  }, [status, result, normalizeSyllabusResult]);
+
+  const handleGoLeft = useCallback(() => {
+    if (courses.length === 0) return;
+    const next = (activeIndex - 1 + courses.length) % courses.length;
+    setActiveIndex(next);
+    listRef.current?.scrollToIndex({ index: next, animated: true });
+  }, [activeIndex, courses.length]);
+
+  const handleGoRight = useCallback(() => {
+    if (courses.length === 0) return;
+    const next = (activeIndex + 1) % courses.length;
+    setActiveIndex(next);
+    listRef.current?.scrollToIndex({ index: next, animated: true });
+  }, [activeIndex, courses.length]);
+
+  const updateCourseSection = useCallback((courseIdx, sectionKey, updater) => {
+    setCourses((prev) => {
+      const next = [...prev];
+      const course = { ...next[courseIdx] };
+      const currentSection = Array.isArray(course[sectionKey]) ? course[sectionKey] : [];
+      course[sectionKey] = updater(currentSection);
+      next[courseIdx] = course;
+      return next;
+    });
+  }, []);
+
+  const renderActiveCourse = useCallback(() => {
+    const item = courses[activeIndex];
+    if (!item) return null;
+    return (
+      <CoursePage
+        key={`course-${activeIndex}`}
+        course={item}
+        courseIndex={activeIndex}
+        availableHeight={availableHeight}
+        onEditSection={(section, updater) => updateCourseSection(activeIndex, section, updater)}
+      />
+    );
+  }, [courses, activeIndex, availableHeight, updateCourseSection]);
+
   return (
     <View style={[
       styles.mockpage,
@@ -106,13 +250,48 @@ export default function SyllabusScreen() {
           <Text style={styles.loadingText}>Loading...</Text>
         </View>
       ) : result ? (
+        courses.length > 0 ? (
+          <ScrollView
+            style={styles.carouselScroll}
+            contentContainerStyle={{ alignItems: "center", paddingBottom: TAB_BAR_HEIGHT + 12 }}
+          >
+            <View style={styles.carouselContainer}>
+            <Text style={styles.headerText}>Does this info look correct?</Text>
+            <View style={styles.carouselControls}>
+              <TouchableOpacity onPress={handleGoLeft} style={styles.navButton} accessibilityLabel="Previous course">
+                <Feather name="chevron-left" size={24} color={Colors.white} />
+              </TouchableOpacity>
+              <Text style={styles.carouselTitle}>
+                {courses[activeIndex]?.name || "Course"}
+              </Text>
+              <TouchableOpacity onPress={handleGoRight} style={styles.navButton} accessibilityLabel="Next course">
+                <Feather name="chevron-right" size={24} color={Colors.white} />
+              </TouchableOpacity>
+            </View>
+            <View style={{ width: "100%" }}>
+              {renderActiveCourse()}
+            </View>
+            <View style={styles.buttonRow}>
+              <TouchableOpacity
+                activeOpacity={0.8}
+                style={[styles.ctaButton, styles.secondaryButton]}
+                onPress={() => { setResult(null); setCourses([]); setStatus("idle"); }}
+              >
+                <Text style={styles.tryAgainText}>Upload more</Text>
+              </TouchableOpacity>
+              <ContinueButton courses={courses} onContinue={() => router.push("/(tabs)/syllabus/questions")} />
+            </View>
+            </View>
+          </ScrollView>
+        ) : (
         <ScrollView style={styles.resultContainer} contentContainerStyle={{ alignItems: "center" }}>
-          <Text style={styles.resultTitle}>Result</Text>
+            <Text style={styles.resultTitle}>Preview</Text>
           <Text style={styles.resultJson}>{JSON.stringify(result, null, 2)}</Text>
           <TouchableOpacity activeOpacity={0.8} style={styles.tryAgain} onPress={() => { setResult(null); setStatus("idle"); }}>
             <Text style={styles.tryAgainText}>Upload more</Text>
           </TouchableOpacity>
         </ScrollView>
+        )
       ) : (
         <TouchableOpacity
           activeOpacity={0.8}
@@ -140,6 +319,9 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.backgroundBlue,
     color: Colors.backgroundBlue,
   },
+  carouselScroll: {
+    width: "100%",
+  },
   uploadBox: {
     width: "92%",
     paddingVertical: 40,
@@ -152,6 +334,43 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     gap: 8,
+  },
+  carouselContainer: {
+    width: "92%",
+    backgroundColor: "rgba(64, 71, 94, 0.25)",
+    borderRadius: 16,
+    borderWidth: 2,
+    borderStyle: "dashed",
+    borderColor: Colors.borderGray,
+    padding: 12,
+    gap: 10,
+  },
+  headerText: {
+    color: Colors.backgroundBlue,
+    textAlign: "center",
+    fontSize: 16,
+    fontWeight: "600",
+    backgroundColor: Colors.white,
+    paddingVertical: 8,
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  carouselControls: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 8,
+    marginBottom: 6,
+  },
+  carouselTitle: {
+    flex: 1,
+    textAlign: "center",
+    color: Colors.lightBlue,
+    fontSize: 18,
+    fontWeight: "700",
+  },
+  navButton: {
+    padding: 6,
   },
   uploadTitle: {
     marginTop: 6,
@@ -209,5 +428,385 @@ const styles = StyleSheet.create({
     color: "white",
     fontWeight: "600",
   },
+  buttonRow: {
+    flexDirection: "row",
+    gap: 10,
+    width: "100%",
+    marginTop: 12,
+  },
+  ctaButton: {
+    flex: 1,
+    alignSelf: "center",
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    backgroundColor: Colors.green600,
+    borderRadius: 10,
+    alignItems: "center",
+  },
+  secondaryButton: {
+    backgroundColor: Colors.buttonBlue,
+  },
+  disabledButton: {
+    opacity: 0.6,
+  },
+  // course page
+  courseCard: {
+    width: "100%",
+    flex: 1,
+    paddingHorizontal: 6,
+  },
+  courseContent: {
+    width: "100%",
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: Colors.borderGray,
+    backgroundColor: "rgba(0,0,0,0.15)",
+    padding: 12,
+    gap: 8,
+  },
+  sectionContainer: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: Colors.borderGray,
+    backgroundColor: "rgba(255,255,255,0.05)",
+    padding: 10,
+    marginBottom: 8,
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 6,
+  },
+  sectionTitle: {
+    color: Colors.white,
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  editButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+    backgroundColor: Colors.buttonBlue,
+  },
+  editButtonText: {
+    color: Colors.white,
+    fontWeight: "600",
+  },
+  itemsScrollArea: {
+    maxHeight: 140,
+  },
+  itemRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(255,255,255,0.1)",
+  },
+  itemText: {
+    color: Colors.white,
+  },
+  itemDate: {
+    color: Colors.gray400,
+    marginLeft: 12,
+  },
+  emptyText: {
+    color: Colors.gray300,
+    fontStyle: "italic",
+  },
+  // modal
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.6)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 16,
+  },
+  modalCard: {
+    width: "92%",
+    backgroundColor: Colors.menuBlue,
+    borderRadius: 12,
+    padding: 14,
+  },
+  modalTitle: {
+    color: Colors.white,
+    fontSize: 16,
+    fontWeight: "700",
+    marginBottom: 8,
+  },
+  input: {
+    backgroundColor: Colors.gray200,
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    marginVertical: 6,
+    fontSize: 14,
+  },
+  missingBanner: {
+    backgroundColor: Colors.menuBlue,
+    borderRadius: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: Colors.borderGray,
+  },
+  missingBannerText: {
+    color: Colors.white,
+    fontWeight: "600",
+  },
+  modalActions: {
+    marginTop: 10,
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 10,
+  },
+  danger: {
+    backgroundColor: Colors.red500,
+  },
 });
+
+function CoursePage({ course, courseIndex, availableHeight, onEditSection }) {
+  const [modalVisible, setModalVisible] = useState(false);
+  const [modalSection, setModalSection] = useState(null);
+  const [newTitle, setNewTitle] = useState("");
+  const [newDue, setNewDue] = useState("");
+  const [editingIndex, setEditingIndex] = useState(null);
+
+  const openEdit = (section, targetIndex = null) => {
+    setModalSection(section);
+    if (targetIndex !== null && Array.isArray(course[section]) && course[section][targetIndex]) {
+      const it = course[section][targetIndex];
+      setNewTitle(it.title || it.name || "");
+      setNewDue(it.dueDate || it.date || "");
+      setEditingIndex(targetIndex);
+    } else {
+      setNewTitle("");
+      setNewDue("");
+      setEditingIndex(null);
+    }
+    setModalVisible(true);
+  };
+
+  const closeEdit = () => {
+    setModalVisible(false);
+    setEditingIndex(null);
+  };
+
+  const handleAddItem = () => {
+    if (!modalSection) return;
+    const trimmedTitle = (newTitle || "").trim();
+    const trimmedDue = (newDue || "").trim();
+    if (!trimmedTitle || !trimmedDue) {
+      return;
+    }
+    if (editingIndex !== null) {
+      onEditSection(modalSection, (items) => {
+        const next = [...items];
+        const existing = next[editingIndex] || {};
+        next[editingIndex] = { ...existing, title: trimmedTitle, name: trimmedTitle, dueDate: trimmedDue };
+        return next;
+      });
+    } else {
+      onEditSection(modalSection, (items) => [...items, { title: trimmedTitle, name: trimmedTitle, dueDate: trimmedDue }]);
+    }
+    setNewTitle("");
+    setNewDue("");
+    setEditingIndex(null);
+  };
+
+  const handleDeleteItem = (idx) => {
+    if (!modalSection) return;
+    onEditSection(modalSection, (items) => items.filter((_, i) => i !== idx));
+  };
+
+  const renderItems = (list, label) => {
+    if (!list || list.length === 0) {
+      return (
+        <Text style={styles.emptyText}>
+          Orbit couldn't detect any {label?.toLowerCase?.()}. Would you like to add some?
+        </Text>
+      );
+    }
+    return (
+      <>
+        {list.map((it, idx) => (
+          <View key={idx} style={styles.itemRow}>
+            <View style={{ flexDirection: "row", alignItems: "center", flex: 1 }}>
+              <Text style={styles.itemText}>{it.title || it.name || "Untitled"}</Text>
+              {(it.dueDate || it.date) ? (
+                <Text style={styles.itemDate}>{it.dueDate || it.date}</Text>
+              ) : null}
+            </View>
+          </View>
+        ))}
+      </>
+    );
+  };
+
+  return (
+    <View style={[styles.courseCard, { minHeight: Math.max(360, availableHeight - 120) }]}>
+      <ScrollView style={{ flex: 1, width: "100%" }} contentContainerStyle={{ paddingBottom: 12 }}>
+        <View style={styles.courseContent}>
+          {/* Sections */}
+          <Section
+            title="Exams"
+          onEdit={() => openEdit("exams")}
+          missingIndex={firstMissingIndex(course.exams)}
+          onFixMissing={() => {
+            const idx = firstMissingIndex(course.exams);
+            if (idx !== -1) openEdit("exams", idx);
+          }}
+            childrenScrollable
+          >
+          <ScrollView style={styles.itemsScrollArea}>
+            {renderItems(course.exams, "Exams")}
+            </ScrollView>
+          </Section>
+        <Section
+          title="Projects"
+          onEdit={() => openEdit("projects")}
+          missingIndex={firstMissingIndex(course.projects)}
+          onFixMissing={() => {
+            const idx = firstMissingIndex(course.projects);
+            if (idx !== -1) openEdit("projects", idx);
+          }}
+          childrenScrollable
+        >
+          <ScrollView style={styles.itemsScrollArea}>
+            {renderItems(course.projects, "Projects")}
+            </ScrollView>
+          </Section>
+        <Section
+          title="Assignments"
+          onEdit={() => openEdit("assignments")}
+          missingIndex={firstMissingIndex(course.assignments)}
+          onFixMissing={() => {
+            const idx = firstMissingIndex(course.assignments);
+            if (idx !== -1) openEdit("assignments", idx);
+          }}
+          childrenScrollable
+        >
+          <ScrollView style={styles.itemsScrollArea}>
+            {renderItems(course.assignments, "Assignments")}
+            </ScrollView>
+          </Section>
+        <Section
+          title="Quizzes"
+          onEdit={() => openEdit("quizzes")}
+          missingIndex={firstMissingIndex(course.quizzes)}
+          onFixMissing={() => {
+            const idx = firstMissingIndex(course.quizzes);
+            if (idx !== -1) openEdit("quizzes", idx);
+          }}
+          childrenScrollable
+        >
+          <ScrollView style={styles.itemsScrollArea}>
+            {renderItems(course.quizzes, "Quizzes")}
+            </ScrollView>
+          </Section>
+        </View>
+      </ScrollView>
+
+      <Modal visible={modalVisible} transparent animationType="fade" onRequestClose={closeEdit}>
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalCard}>
+            <Text style={styles.modalTitle}>
+              Edit {modalSection ? modalSection[0].toUpperCase() + modalSection.slice(1) : ""}
+            </Text>
+            <TextInput
+              value={newTitle}
+              onChangeText={setNewTitle}
+              placeholder="Title"
+              placeholderTextColor="#555"
+              style={styles.input}
+            />
+            <TextInput
+              value={newDue}
+              onChangeText={setNewDue}
+              placeholder="Due date"
+              placeholderTextColor="#555"
+              style={styles.input}
+            />
+            <TouchableOpacity style={styles.editButton} onPress={handleAddItem} disabled={!newTitle.trim() || !newDue.trim()}>
+              <Text style={styles.editButtonText}>{editingIndex !== null ? "Save" : "Add"}</Text>
+            </TouchableOpacity>
+            <View style={{ marginTop: 8 }}>
+              {(course[modalSection] || []).map((it, idx) => (
+                <View key={`md-${idx}`} style={[styles.itemRow, { paddingVertical: 8 }]}>
+                  <Text style={styles.itemText}>
+                    {(it.title || it.name || "Untitled") + (it.dueDate || it.date ? ` — ${it.dueDate || it.date}` : "")}
+                  </Text>
+                  <TouchableOpacity style={styles.editButton} onPress={() => openEdit(modalSection, idx)}>
+                    <Text style={styles.editButtonText}>Edit</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity style={[styles.editButton, styles.danger]} onPress={() => handleDeleteItem(idx)}>
+                    <Text style={styles.editButtonText}>Delete</Text>
+                  </TouchableOpacity>
+                </View>
+              ))}
+            </View>
+            <View style={styles.modalActions}>
+              <TouchableOpacity style={styles.editButton} onPress={closeEdit}>
+                <Text style={styles.editButtonText}>Done</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+function Section({ title, onEdit, childrenScrollable, children }) {
+  return (
+    <View style={styles.sectionContainer}>
+      <View style={styles.sectionHeader}>
+        <Text style={styles.sectionTitle}>{title}</Text>
+        <TouchableOpacity style={styles.editButton} onPress={onEdit}>
+          <Text style={styles.editButtonText}>Edit</Text>
+        </TouchableOpacity>
+      </View>
+      {typeof arguments[0]?.missingIndex === "number" && arguments[0].missingIndex !== -1 ? (
+        <TouchableOpacity style={styles.missingBanner} onPress={arguments[0].onFixMissing}>
+          <Text style={styles.missingBannerText}>*We detected missing dates, add to continue!*</Text>
+        </TouchableOpacity>
+      ) : null}
+      {childrenScrollable ? children : <View>{children}</View>}
+    </View>
+  );
+}
+
+function firstMissingIndex(arr) {
+  return Array.isArray(arr) ? arr.findIndex((it) => !(it?.dueDate || it?.date)) : -1;
+}
+
+function firstMissingInCourse(course) {
+  const check = (arr) => firstMissingIndex(arr);
+  const sections = ["exams", "projects", "assignments", "quizzes"];
+  for (const s of sections) {
+    const idx = check(course?.[s]);
+    if (idx !== -1) return { section: s, index: idx };
+  }
+  return null;
+}
+
+function hasAnyMissingDueDate(courses) {
+  return (courses || []).some((c) => firstMissingInCourse(c));
+}
+
+function ContinueButton({ courses, onContinue }) {
+  const disabled = hasAnyMissingDueDate(courses);
+  return (
+    <TouchableOpacity
+      activeOpacity={0.8}
+      style={[styles.ctaButton, disabled && styles.disabledButton]}
+      disabled={disabled}
+      onPress={onContinue}
+    >
+      <Text style={styles.tryAgainText}>Continue</Text>
+    </TouchableOpacity>
+  );
+}
 

--- a/frontend/app/(tabs)/syllabus/questions.jsx
+++ b/frontend/app/(tabs)/syllabus/questions.jsx
@@ -1,0 +1,527 @@
+import React, { useMemo, useState } from "react";
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, ActivityIndicator, Modal } from "react-native";
+import Colors from "@/constants/Colors";
+import { useRouter } from "expo-router";
+import { useSyllabus } from "@/context/SyllabusContext";
+import { useAuth } from "@/context/AuthContext";
+import API from "@/api/api";
+
+// keep footer above tab bar
+const TAB_BAR_HEIGHT = 85;
+
+const QuestionsScreen = () => {
+    const router = useRouter();
+    const { getSyllabusPayload } = useSyllabus();
+    const { userData } = useAuth();
+
+    const selectableTypes = useMemo(() => ([
+        "Assignments",
+        "Projects",
+        "Exams",
+        "Quizzes",
+    ]), []);
+
+    const [selectedTypes, setSelectedTypes] = useState(new Set());
+    const [hoursByType, setHoursByType] = useState({});
+    const [openDropdown, setOpenDropdown] = useState(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [showResultModal, setShowResultModal] = useState(false);
+    const [calendarEntries, setCalendarEntries] = useState([]);
+    const [isFetchingCalendar, setIsFetchingCalendar] = useState(false);
+
+    const fetchCalendarEntries = async (retryCount = 0) => {
+        setIsFetchingCalendar(true);
+        try {
+            const calendarRes = await API.get("/studyplans/calendar");
+            console.log("[StudyPlan] Calendar entries:", calendarRes.data);
+            setCalendarEntries(calendarRes.data.entries || []);
+        } catch (calErr) {
+            console.error("[StudyPlan] Failed to fetch calendar:", calErr);
+            // retry on auth error
+            if (calErr.response?.status === 401 && retryCount < 2) {
+                console.log("[StudyPlan] Auth error, retrying in 1s...");
+                await new Promise(r => setTimeout(r, 1000));
+                return fetchCalendarEntries(retryCount + 1);
+            }
+            setCalendarEntries([]);
+        } finally {
+            setIsFetchingCalendar(false);
+        }
+    };
+
+    if (isLoading) {
+        return (
+            <View style={styles.loadingWrapper}>
+                <ActivityIndicator size="large" color={Colors.lightBlue} />
+                <Text style={styles.loadingText}>Generating your study plans...</Text>
+            </View>
+        );
+    }
+
+    return (
+        <View style={styles.wrapper}>
+        {/* Result Modal for testing */}
+        <Modal
+            visible={showResultModal}
+            transparent
+            animationType="slide"
+            onRequestClose={() => setShowResultModal(false)}
+        >
+            <View style={styles.modalOverlay}>
+                <View style={styles.modalContent}>
+                    <Text style={styles.modalTitle}>Study Plan Generated!</Text>
+                    <Text style={styles.modalSubtitle}>{calendarEntries.length} entries found</Text>
+                    <ScrollView style={styles.modalScroll}>
+                        {calendarEntries.length === 0 ? (
+                            <View style={styles.emptyContainer}>
+                                <Text style={styles.modalEmpty}>No entries found. The workflow may still be processing.</Text>
+                                <TouchableOpacity 
+                                    style={[styles.retryBtn, isFetchingCalendar && styles.disabledBtn]} 
+                                    onPress={fetchCalendarEntries}
+                                    disabled={isFetchingCalendar}
+                                >
+                                    <Text style={styles.retryBtnText}>{isFetchingCalendar ? "Retrying..." : "Retry"}</Text>
+                                </TouchableOpacity>
+                            </View>
+                        ) : (
+                            calendarEntries.map((entry, idx) => (
+                                <View key={idx} style={styles.entryCard}>
+                                    <View style={styles.entryHeader}>
+                                        <Text style={styles.entryName}>{entry.assessmentName}</Text>
+                                        <Text style={styles.entryCourse}>{entry.course}</Text>
+                                    </View>
+                                    {entry.dueDate && (
+                                        <Text style={styles.entryDueDate}>Due: {entry.dueDate}</Text>
+                                    )}
+                                    {entry.tasks && entry.tasks.length > 0 && (
+                                        <View style={styles.tasksList}>
+                                            {entry.tasks.map((task, tIdx) => (
+                                                <View key={tIdx} style={styles.taskItem}>
+                                                    <Text style={styles.taskText}>
+                                                        • {typeof task === 'string' ? task : task.task}
+                                                    </Text>
+                                                    {typeof task !== 'string' && task.estimatedTime && (
+                                                        <Text style={styles.taskTime}>{task.estimatedTime}</Text>
+                                                    )}
+                                                </View>
+                                            ))}
+                                        </View>
+                                    )}
+                                </View>
+                            ))
+                        )}
+                    </ScrollView>
+                    <TouchableOpacity 
+                        style={styles.modalCloseBtn} 
+                        onPress={() => {
+                            setShowResultModal(false);
+                            router.push("/(tabs)/calendar");
+                        }}
+                    >
+                        <Text style={styles.modalCloseBtnText}>Go to Calendar</Text>
+                    </TouchableOpacity>
+                </View>
+            </View>
+        </Modal>
+
+        <ScrollView style={styles.container} contentContainerStyle={{ paddingBottom: TAB_BAR_HEIGHT + 24 }}>
+            <View style={styles.card}>
+                <Text style={styles.title}>I want study plans for:</Text>
+                <Text style={styles.subtitle}>(select all that apply)</Text>
+                <View style={styles.chipsRow}>
+                    {selectableTypes.map((label) => {
+                        const isSelected = selectedTypes.has(label);
+                        return (
+                            <TouchableOpacity
+                                key={label}
+                                style={[styles.chip, isSelected && styles.chipSelected]}
+                                onPress={() => {
+                                    setOpenDropdown(null);
+                                    setSelectedTypes((prev) => {
+                                        const next = new Set(prev);
+                                        if (next.has(label)) {
+                                            next.delete(label);
+                                        } else {
+                                            next.add(label);
+                                        }
+                                        return next;
+                                    });
+                                }}
+                            >
+                                <Text style={[styles.chipText, isSelected && styles.chipTextSelected]}>{label}</Text>
+                            </TouchableOpacity>
+                        );
+                    })}
+                </View>
+            </View>
+
+            {selectedTypes.size > 0 ? (
+                <View style={styles.card}>
+                    <Text style={styles.title}>I usually study about...</Text>
+                    {[...selectedTypes].map((label) => {
+                        const currentValue = hoursByType[label];
+                        const isOpen = openDropdown === label;
+                        const hourOptions = ["1","2","3","4","5","6","7","8","9","10+","N/A"];
+                        return (
+                            <View key={label} style={styles.dropdownGroup}>
+                                <Text style={styles.dropdownLabel}>{label}</Text>
+                                <TouchableOpacity
+                                    style={styles.dropdownButton}
+                                    onPress={() => setOpenDropdown(isOpen ? null : label)}
+                                >
+                                    <Text style={styles.dropdownButtonText}>
+                                        {currentValue ? (currentValue === "N/A" ? "N/A" : `${currentValue} hours`) : "Select hours"}
+                                    </Text>
+                                </TouchableOpacity>
+                                {isOpen ? (
+                                    <View style={styles.dropdownList}>
+                                        {hourOptions.map((opt) => (
+                                            <TouchableOpacity
+                                                key={`${label}-${opt}`}
+                                                style={styles.dropdownItem}
+                                                onPress={() => {
+                                                    setHoursByType((prev) => ({ ...prev, [label]: opt }));
+                                                    setOpenDropdown(null);
+                                                }}
+                                            >
+                                                <Text style={styles.dropdownItemText}>{opt === "N/A" ? "N/A" : `${opt} hours`}</Text>
+                                            </TouchableOpacity>
+                                        ))}
+                                    </View>
+                                ) : null}
+                            </View>
+                        );
+                    })}
+                </View>
+            ) : null}
+
+            <View style={styles.footerSpacer} />
+        </ScrollView>
+            <View style={styles.footerBar}>
+                <TouchableOpacity style={[styles.backBtn, styles.footerBtn]} onPress={() => router.back()}>
+                    <Text style={styles.backBtnText}>Back to review</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                    style={[styles.generateBtn, styles.footerBtn, (selectedTypes.size === 0 || isLoading) && styles.disabledBtn]}
+                    disabled={selectedTypes.size === 0 || isLoading}
+                    onPress={async () => {
+                        setIsLoading(true);
+                        try {
+                            const { syllabi, sourceFiles, uploadId } = getSyllabusPayload();
+
+                            // build courses array with active/null sections
+                            const courses = syllabi.map((course) => {
+                                const buildSection = (key, label) => {
+                                    const isActive = selectedTypes.has(label);
+                                    if (!isActive) {
+                                        return null;
+                                    }
+                                    return {
+                                        active: true,
+                                        studyTime: hoursByType[label] || null,
+                                        items: course[key] || [],
+                                    };
+                                };
+
+                                return {
+                                    name: course.name,
+                                    assignments: buildSection("assignments", "Assignments"),
+                                    projects: buildSection("projects", "Projects"),
+                                    exams: buildSection("exams", "Exams"),
+                                    quizzes: buildSection("quizzes", "Quizzes"),
+                                };
+                            });
+
+                            // debug
+                            console.log("[StudyPlan] userData:", JSON.stringify(userData, null, 2));
+                            
+                            const payload = {
+                                courses,
+                                sourceFiles,
+                                uploadId,
+                                userId: userData?._id || userData?.id || null,
+                                meta: { requestedAt: new Date().toISOString() },
+                            };
+
+                            console.log("[StudyPlan] Sending payload:", JSON.stringify(payload, null, 2));
+                            const response = await API.post("/study-plan", payload);
+                            console.log("[StudyPlan] Response:", response.data);
+                            
+                            // webhook responds after mongo insert, fetch now
+                            await fetchCalendarEntries();
+                            setShowResultModal(true);
+                        } catch (e) {
+                            console.error("[StudyPlan] Failed to send:", e);
+                        } finally {
+                            setIsLoading(false);
+                        }
+                    }}
+                >
+                    <Text style={styles.generateBtnText}>Generate My Study Plans</Text>
+                </TouchableOpacity>
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    wrapper: {
+        flex: 1,
+        backgroundColor: Colors.backgroundBlue,
+    },
+    loadingWrapper: {
+        flex: 1,
+        backgroundColor: Colors.backgroundBlue,
+        justifyContent: "center",
+        alignItems: "center",
+        gap: 16,
+    },
+    loadingText: {
+        color: Colors.lightBlue,
+        fontSize: 16,
+        fontWeight: "600",
+    },
+    container: {
+        flex: 1,
+        padding: 10,
+    },
+    card: {
+        borderRadius: 16,
+        borderWidth: 2,
+        borderStyle: "dashed",
+        borderColor: Colors.borderGray,
+        backgroundColor: "rgba(64, 71, 94, 0.25)",
+        padding: 16,
+        gap: 10,
+        marginBottom: 12,
+    },
+    title: {
+        color: Colors.lightBlue,
+        fontWeight: "700",
+        fontSize: 18,
+        textAlign: "center",
+        marginBottom: 4,
+    },
+    subtitle: {
+        color: Colors.gray400,
+        textAlign: "center",
+        marginBottom: 8,
+        fontSize: 12,
+    },
+    chipsRow: {
+        flexDirection: "row",
+        flexWrap: "wrap",
+        gap: 8,
+        justifyContent: "center",
+    },
+    chip: {
+        borderWidth: 1,
+        borderColor: Colors.borderGray,
+        borderRadius: 20,
+        paddingVertical: 6,
+        paddingHorizontal: 12,
+        backgroundColor: "transparent",
+    },
+    chipSelected: {
+        backgroundColor: Colors.buttonBlue,
+    },
+    chipText: {
+        color: Colors.white,
+        fontWeight: "500",
+    },
+    chipTextSelected: {
+        color: Colors.white,
+        fontWeight: "700",
+    },
+    dropdownGroup: {
+        marginTop: 8,
+    },
+    dropdownLabel: {
+        color: Colors.white,
+        marginBottom: 6,
+        fontWeight: "600",
+    },
+    dropdownButton: {
+        borderWidth: 1,
+        borderColor: Colors.borderGray,
+        borderRadius: 8,
+        paddingVertical: 10,
+        paddingHorizontal: 12,
+        backgroundColor: Colors.menuBlue,
+    },
+    dropdownButtonText: {
+        color: Colors.white,
+        fontWeight: "600",
+    },
+    dropdownList: {
+        marginTop: 6,
+        borderWidth: 1,
+        borderColor: Colors.borderGray,
+        borderRadius: 8,
+        overflow: "hidden",
+        backgroundColor: Colors.menuBlue,
+    },
+    dropdownItem: {
+        paddingVertical: 10,
+        paddingHorizontal: 12,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: "rgba(255,255,255,0.15)",
+    },
+    dropdownItemText: {
+        color: Colors.white,
+    },
+    generateBtn: {
+        alignSelf: "stretch",
+        paddingVertical: 12,
+        backgroundColor: Colors.green600,
+        borderRadius: 10,
+        alignItems: "center",
+    },
+    generateBtnText: {
+        color: Colors.white,
+        fontWeight: "700",
+        textAlign: "center",
+    },
+    backBtn: {
+        alignSelf: "center",
+        paddingVertical: 10,
+        paddingHorizontal: 16,
+        backgroundColor: Colors.buttonBlue,
+        borderRadius: 10,
+        alignItems: "center",
+    },
+    backBtnText: {
+        color: Colors.white,
+        fontWeight: "600",
+        textAlign: "center",
+    },
+    disabledBtn: {
+        opacity: 0.6,
+    },
+    footerBar: {
+        position: "absolute",
+        left: 10,
+        right: 10,
+        bottom: TAB_BAR_HEIGHT + 10,
+        flexDirection: "row",
+        justifyContent: "space-between",
+        gap: 10,
+    },
+    footerBtn: {
+        flex: 1,
+    },
+    footerSpacer: {
+        height: 140,
+    },
+    // modal
+    modalOverlay: {
+        flex: 1,
+        backgroundColor: "rgba(0,0,0,0.7)",
+        justifyContent: "center",
+        alignItems: "center",
+        padding: 20,
+    },
+    modalContent: {
+        backgroundColor: Colors.menuBlue,
+        borderRadius: 16,
+        padding: 20,
+        width: "100%",
+        maxHeight: "80%",
+    },
+    modalTitle: {
+        color: Colors.lightBlue,
+        fontSize: 20,
+        fontWeight: "700",
+        textAlign: "center",
+        marginBottom: 4,
+    },
+    modalSubtitle: {
+        color: Colors.gray400,
+        fontSize: 14,
+        textAlign: "center",
+        marginBottom: 16,
+    },
+    modalScroll: {
+        maxHeight: 400,
+    },
+    modalEmpty: {
+        color: Colors.gray400,
+        textAlign: "center",
+        marginBottom: 16,
+    },
+    emptyContainer: {
+        alignItems: "center",
+        padding: 20,
+    },
+    retryBtn: {
+        backgroundColor: Colors.green600,
+        paddingVertical: 10,
+        paddingHorizontal: 24,
+        borderRadius: 8,
+    },
+    retryBtnText: {
+        color: Colors.white,
+        fontWeight: "600",
+    },
+    entryCard: {
+        backgroundColor: "rgba(255,255,255,0.1)",
+        borderRadius: 10,
+        padding: 14,
+        marginBottom: 12,
+    },
+    entryHeader: {
+        marginBottom: 6,
+    },
+    entryName: {
+        color: Colors.white,
+        fontSize: 15,
+        fontWeight: "700",
+    },
+    entryCourse: {
+        color: Colors.lightBlue,
+        fontSize: 12,
+        fontWeight: "500",
+        marginTop: 2,
+    },
+    entryDueDate: {
+        color: Colors.yellowstar,
+        fontSize: 12,
+        fontWeight: "600",
+        marginBottom: 8,
+    },
+    tasksList: {
+        borderTopWidth: 1,
+        borderTopColor: "rgba(255,255,255,0.1)",
+        paddingTop: 8,
+        marginTop: 4,
+    },
+    taskItem: {
+        marginBottom: 8,
+    },
+    taskText: {
+        color: Colors.gray300 || "#d1d5db",
+        fontSize: 13,
+        lineHeight: 18,
+    },
+    taskTime: {
+        color: Colors.green400,
+        fontSize: 11,
+        marginTop: 2,
+        marginLeft: 12,
+    },
+    modalCloseBtn: {
+        backgroundColor: Colors.buttonBlue,
+        borderRadius: 10,
+        paddingVertical: 12,
+        marginTop: 16,
+        alignItems: "center",
+    },
+    modalCloseBtnText: {
+        color: Colors.white,
+        fontWeight: "600",
+    },
+});
+
+export default QuestionsScreen;
+
+

--- a/frontend/app/_layout.jsx
+++ b/frontend/app/_layout.jsx
@@ -1,6 +1,7 @@
 import { AuthProvider } from "@/context/AuthContext";
 import { LoadingProvider } from "@/context/LoadingContext";
 import { CustomAlertProvider } from "@/context/CustomAlertContext";
+import { SyllabusProvider } from "@/context/SyllabusContext";
 import RootLayout from "./RootLayout";
 import { useEffect } from "react";
 
@@ -18,7 +19,9 @@ const RootLayoutWrapper = () => {
         <LoadingProvider>
             <CustomAlertProvider>
                 <AuthProvider>
+                    <SyllabusProvider>
                     <RootLayout />
+                    </SyllabusProvider>
                 </AuthProvider>
             </CustomAlertProvider>
         </LoadingProvider>

--- a/frontend/context/SyllabusContext.js
+++ b/frontend/context/SyllabusContext.js
@@ -1,0 +1,80 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { Platform } from "react-native";
+
+const SyllabusContext = createContext();
+
+export const SyllabusProvider = ({ children }) => {
+    const [rawResult, setRawResult] = useState(null);
+    const [courses, setCourses] = useState([]);
+    const [studyPlan, setStudyPlan] = useState(null);
+    const [uploadId, setUploadId] = useState(null);
+    const [uploadedFiles, setUploadedFiles] = useState([]);
+
+    // persist to localstorage on web
+    useEffect(() => {
+        if (Platform.OS === "web") {
+            try {
+                if (rawResult) {
+                    localStorage.setItem("syllabus.rawResult", JSON.stringify(rawResult));
+                }
+                localStorage.setItem("syllabus.courses", JSON.stringify(courses || []));
+                if (studyPlan) {
+                    localStorage.setItem("syllabus.studyPlan", JSON.stringify(studyPlan));
+                }
+                if (uploadId) {
+                    localStorage.setItem("syllabus.uploadId", String(uploadId));
+                }
+                localStorage.setItem("syllabus.uploadedFiles", JSON.stringify(uploadedFiles || []));
+            } catch (_e) {
+                // ignore
+            }
+        }
+    }, [rawResult, courses, studyPlan, uploadId, uploadedFiles]);
+
+    useEffect(() => {
+        if (Platform.OS === "web") {
+            try {
+                const savedCourses = localStorage.getItem("syllabus.courses");
+                const savedRaw = localStorage.getItem("syllabus.rawResult");
+                const savedPlan = localStorage.getItem("syllabus.studyPlan");
+                const savedUploadId = localStorage.getItem("syllabus.uploadId");
+                const savedUploadedFiles = localStorage.getItem("syllabus.uploadedFiles");
+                if (savedCourses) setCourses(JSON.parse(savedCourses));
+                if (savedRaw) setRawResult(JSON.parse(savedRaw));
+                if (savedPlan) setStudyPlan(JSON.parse(savedPlan));
+                if (savedUploadId) setUploadId(savedUploadId);
+                if (savedUploadedFiles) setUploadedFiles(JSON.parse(savedUploadedFiles));
+            } catch (_e) {
+                // ignore
+            }
+        }
+    }, []);
+
+    const value = useMemo(() => ({
+        rawResult,
+        setRawResult,
+        courses,
+        setCourses,
+        studyPlan,
+        setStudyPlan,
+        uploadId,
+        setUploadId,
+        uploadedFiles,
+        setUploadedFiles,
+        // helper to build payload for webhooks
+        getSyllabusPayload: () => ({
+            syllabi: courses || [],
+            studyPlan: studyPlan || null,
+            sourceFiles: uploadedFiles || [],
+            uploadId: uploadId || null,
+            meta: { savedAt: new Date().toISOString() },
+        }),
+    }), [rawResult, courses, studyPlan, uploadId, uploadedFiles]);
+
+    return <SyllabusContext.Provider value={value}>{children}</SyllabusContext.Provider>;
+};
+
+export const useSyllabus = () => useContext(SyllabusContext);
+
+
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.2",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
@@ -2860,6 +2861,183 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -15423,183 +15601,6 @@
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/vaul/node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
-      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vaul/node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vaul/node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
-      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vaul/node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vaul/node_modules/@radix-ui/react-presence": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
-      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vaul/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vaul/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/vlq": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",


### PR DESCRIPTION
   - Added syllabus review carousel with course cards
   - Added edit modal for assignments/exams/projects/quizzes
   - Added study plan questions screen
   - Added study plan API routes and MongoDB integration
   - Integrated with n8n webhook for study plan generation
 
 **routes for calendar/frontend implementation**  
Study Plan API Routes
All routes require authentication (JWT token).

Get calendar entries: GET /api/studyplans/calendar
Returns the latest study plan's entries sorted by due date. Each entry has:
- `course` - course name
- `assessmentName` - name of the assignment/exam/etc
- `assessmentType` - "Assignment", "Exam", "Project", "Quiz"
- `dueDate` - due date string
- `tasks` - array of study tasks with `task`, `description`, `estimatedTime`

Example response:
{
  "entries": [
    {
      "course": "example",
      "assessmentName": "Exam 1",
      "assessmentType": "Exam",
      "dueDate": "2025-09-16",
      "tasks": [
        { "task": "Review exam 1 review sheet", "estimatedTime": "2 hours" }
      ]
    }
  ],
  "count": 8,
  "studyPlanId": "...",
  "savedAt": "2025-11-30T19:13:11.051Z"
}